### PR TITLE
feat: overlapping row last

### DIFF
--- a/CourseGenerator/Center.lua
+++ b/CourseGenerator/Center.lua
@@ -159,6 +159,10 @@ function Center:generate()
     for _, b in ipairs(self.blocks) do
         lastLocation = b:finalize(entries[b])
     end
+    if self.context.nHeadlands == 0 then
+        self.logger:debug('There is no headland, remove connecting path to first block.')
+        self.connectingPaths[1] = {}
+    end
     self.logger:debug('Found %d block(s), %d connecting path(s).', #self.blocks, #self.connectingPaths)
     if not strict then
         local errorText = 'Could not find the shortest path on headland between blocks'

--- a/CourseGenerator/FieldworkCourse.lua
+++ b/CourseGenerator/FieldworkCourse.lua
@@ -181,7 +181,7 @@ function FieldworkCourse:generateCenter()
         -- width wider than the field boundary so the rows in the center cover the area between the original
         -- field boundaries.
         local virtualHeadland = cg.Headland(self.boundary, self.context.headlandClockwise, 0,
-                self.context.workingWidth / 2, true, self.context.turningRadius)
+                self.context.workingWidth / 2, true)
         self.center = cg.Center(self.context, virtualHeadland, self.context.startLocation, self.bigIslands)
     else
         local innerMostHeadlandPolygon = self.headlands[#self.headlands]:getPolygon()

--- a/ListParameter.lua
+++ b/ListParameter.lua
@@ -32,7 +32,7 @@ end
 ---@return table to use with love.graphics.print()
 function ListParameter:toColoredText(nameColor, keyColor, valueColor)
 	return {nameColor, self.name, keyColor, string.format(' (%s/%s): ', self.down, self.up),
-			valueColor, self.values[self.current]}
+			valueColor, self.names[self.current]}
 end
 
 function ListParameter:__tostring()

--- a/main.lua
+++ b/main.lua
@@ -13,7 +13,7 @@ dofile('include.lua')
 
 local parameters = {}
 -- working width of the equipment
-local workingWidth = AdjustableParameter(16.6, 'width', 'W', 'w', 0.2, 0, 100)
+local workingWidth = AdjustableParameter(6, 'width', 'W', 'w', 0.2, 0, 100)
 table.insert(parameters, workingWidth)
 local turningRadius = AdjustableParameter(7, 'radius', 'T', 't', 0.2, 0, 20)
 table.insert(parameters, turningRadius)
@@ -57,9 +57,9 @@ local nRows = AdjustableParameter(4, 'rows to skip/rows per land', 'K', 'k', 1, 
 table.insert(parameters, nRows)
 local leaveSkippedRowsUnworked = ToggleParameter('leave skipped rows unworked', false, 'u')
 table.insert(parameters, leaveSkippedRowsUnworked)
-local centerClockwise = ToggleParameter('spiral/lands clockwise', true, '1')
+local centerClockwise = ToggleParameter('spiral/lands clockwise', true, 'l')
 table.insert(parameters, centerClockwise)
-local spiralFromInside = ToggleParameter('spiral from inside', true, '!')
+local spiralFromInside = ToggleParameter('spiral from inside', true, 'L')
 table.insert(parameters, spiralFromInside)
 local evenRowDistribution = ToggleParameter('even row width', false, 'e')
 table.insert(parameters, evenRowDistribution)


### PR DESCRIPTION
Make the best effort to have the row that overlaps the headland (or the last row when there is no headland) the last row we work on. This usually works for the alternating/skip pattern, no guarantee for others.

This is a chicken and egg problem especially with fields with multiple blocks as there we don't know where are we 
going to enter the block. One could shift the rows after everything else is done, but that would potentially screw 
up non-rectangular fields, and/or fields with islands.

This solution should work for 99% cases with rectangular, single block fields.

#5