### PR TITLE
feat: racetrack rows to skip parameter

### DIFF
--- a/CourseGenerator/Center.lua
+++ b/CourseGenerator/Center.lua
@@ -489,6 +489,7 @@ function Center:_wrapUpConnectingPaths()
     else
         for _, c in ipairs(self.connectingPaths) do
             c:setAttribute(nil, cg.WaypointAttributes.setOnConnectingPath)
+            c:setAttribute(nil, cg.WaypointAttributes.setHeadlandTurn, nil)
         end
     end
 end

--- a/CourseGenerator/CourseGenerator.lua
+++ b/CourseGenerator/CourseGenerator.lua
@@ -22,6 +22,9 @@ NewCourseGenerator.cRowWaypointDistance = 10
 -- find corners which the vehicle can't make due to its turning radius, without deviating more than
 -- cMaxCrossTrackError meters from the vertex in the corner.
 NewCourseGenerator.cMaxCrossTrackError = 0.5
+-- Maximum cross track error when generating rows parallel to a non-straight field edge. The row will end when
+-- the cross track error is bigger than this limit
+NewCourseGenerator.cMaxCrossTrackErrorForCurvedRows = 0.15
 -- The delta angle above which smoothing kicks in. No smoothing around vertices with a delta
 -- angle below this
 NewCourseGenerator.cMinSmoothingAngle = math.rad(15)

--- a/CourseGenerator/CurvedPathHelper.lua
+++ b/CourseGenerator/CurvedPathHelper.lua
@@ -72,14 +72,14 @@ end
 function CurvedPathHelper.findLongestStraightSection(boundary, ix, radiusThreshold, section)
     local i, n, j = ix, 1
     -- max one round only (n <) self:at(currentIx):getXte(r)
-    while n < #boundary and boundary:at(i):getXte(radiusThreshold) < cg.cMaxCrossTrackError do
+    while n < #boundary and boundary:at(i):getXte(radiusThreshold) < cg.cMaxCrossTrackErrorForCurvedRows do
         section:append((boundary:at(i)):clone())
         i = i - 1
         n = n + 1
     end
     section:reverse()
     j, n = ix + 1, 1
-    while n < #boundary and boundary:at(j):getXte(radiusThreshold) < cg.cMaxCrossTrackError do
+    while n < #boundary and boundary:at(j):getXte(radiusThreshold) < cg.cMaxCrossTrackErrorForCurvedRows do
         section:append((boundary:at(j)):clone())
         j = j + 1
         n = n + 1

--- a/CourseGenerator/FieldworkCourseHelper.lua
+++ b/CourseGenerator/FieldworkCourseHelper.lua
@@ -95,6 +95,7 @@ function FieldworkCourseHelper.createUsableBoundary(originalBoundary, clockwise)
     local usableBoundary = originalBoundary:clone()
     -- some field scans are not perfect and have sudden direction changes which screws up the clockwise calculation
     usableBoundary:removeGlitches()
+    usableBoundary:ensureMinimumEdgeLength(cg.cMinEdgeLength)
     if usableBoundary:isClockwise() ~= clockwise then
         -- all headlands are generated in the same direction as the field boundary,
         -- so if it does not match the required cw/ccw, reverse it

--- a/CourseGenerator/FieldworkCourseTwoSided.lua
+++ b/CourseGenerator/FieldworkCourseTwoSided.lua
@@ -110,7 +110,7 @@ function FieldworkCourseTwoSided:generateHeadlands()
     local intersections = lastStartHeadlandRow:getIntersections(self.middleHeadlandBlock:getFirstRow())
     lastStartHeadlandRow:cutEndAtIx(intersections[1].ixA)
     lastStartHeadlandRow:append(intersections[1].is)
-    lastStartHeadlandRow:setAttribute(#lastStartHeadlandRow, cg.WaypointAttributes.setHeadlandTurn)
+    lastStartHeadlandRow:setAttribute(#lastStartHeadlandRow, cg.WaypointAttributes.setHeadlandTurn, true)
     self.middleHeadlandBlock:getFirstRow():cutStartAtIx(intersections[1].ixB + 1)
 
     -- connect the middle and the end
@@ -121,7 +121,7 @@ function FieldworkCourseTwoSided:generateHeadlands()
         local firstMiddleHeadlandRow = self.middleHeadlandBlock:getFirstRow()
         firstMiddleHeadlandRow:cutEndAtIx(intersections[1].ixB)
         firstMiddleHeadlandRow:append(intersections[1].is)
-        firstMiddleHeadlandRow:setAttribute(#firstMiddleHeadlandRow, cg.WaypointAttributes.setHeadlandTurn)
+        firstMiddleHeadlandRow:setAttribute(#firstMiddleHeadlandRow, cg.WaypointAttributes.setHeadlandTurn, true)
     else
         self.context:addError(self.logger, 'Can\'t connect headlands for this field with the current settings')
         return

--- a/CourseGenerator/Geometry/Polyline.lua
+++ b/CourseGenerator/Geometry/Polyline.lua
@@ -507,10 +507,10 @@ function Polyline:ensureMinimumRadius(r, makeCorners)
                     self.logger:warning(
                             'ensureMinimumRadius (%s): will not sharpen this corner, had to move too far (%.1f) back',
                             debugId, totalMoved)
+                    cg.addDebugPoint(entry:getBase(), debugId .. ' entry')
+                    cg.addDebugPoint(exit:getBase(), debugId .. ' exit')
+                    cg.addDebugPoint(self[currentIx], debugId .. ' center')
                 end
-                cg.addDebugPoint(entry:getBase(), debugId .. ' entry')
-                cg.addDebugPoint(exit:getBase(), debugId .. ' exit')
-                cg.addDebugPoint(self[currentIx], debugId .. ' center')
             else
                 adjustedCornerVertices = makeArc(entry, exit)
             end

--- a/CourseGenerator/Headland.lua
+++ b/CourseGenerator/Headland.lua
@@ -76,7 +76,7 @@ function Headland:getPath()
     -- mark corners as headland turns
     for _, v in ipairs(self.polygon) do
         if v.isCorner then
-            v:getAttributes():setHeadlandTurn()
+            v:getAttributes():setHeadlandTurn(true)
         end
     end
     return self.polygon

--- a/CourseGenerator/RowPattern.lua
+++ b/CourseGenerator/RowPattern.lua
@@ -545,10 +545,12 @@ cg.RowPatternLands = RowPatternLands
 ---@class RowPatternRacetrack
 local RowPatternRacetrack = CpObject(RowPattern)
 
-function RowPatternRacetrack:init()
+---@param nSkip number the number of rows to skip when beginning work. This determines the size of the block, which
+--- will be 2 * nSkip rows
+function RowPatternRacetrack:init(nSkip)
     cg.RowPattern.init(self, 'RowPatternRaceTrack')
     -- by default we skip the first four rows when starting
-    self.nSkip = 4
+    self.nSkip = nSkip or 4
 end
 
 function RowPatternRacetrack:__tostring()

--- a/CourseGenerator/WaypointAttributes.lua
+++ b/CourseGenerator/WaypointAttributes.lua
@@ -182,8 +182,8 @@ function WaypointAttributes:setRowStart()
     self.rowStart = true
 end
 
-function WaypointAttributes:setHeadlandTurn()
-    self.headlandTurn = true
+function WaypointAttributes:setHeadlandTurn(isHeadlandTurn)
+    self.headlandTurn = isHeadlandTurn
 end
 
 function WaypointAttributes:setIslandHeadland()

--- a/main.lua
+++ b/main.lua
@@ -14,7 +14,7 @@ dofile('include.lua')
 local logger = Logger('main', Logger.level.debug)
 local parameters = {}
 -- working width of the equipment
-local workingWidth = AdjustableParameter(24, 'width', 'W', 'w', 0.2, 0, 100)
+local workingWidth = AdjustableParameter(6, 'width', 'W', 'w', 0.2, 0, 100)
 table.insert(parameters, workingWidth)
 local turningRadius = AdjustableParameter(7, 'radius', 'T', 't', 0.2, 0, 20)
 table.insert(parameters, turningRadius)
@@ -163,12 +163,16 @@ local function generate()
     if profilerEnabled then
         love.profiler.start()
     end
-    if rowPattern:get() == cg.RowPattern.SPIRAL then
+    if rowPattern:get() == cg.RowPattern.SKIP then
+        context:setRowPattern(cg.RowPattern.create(rowPattern:get(), nRows:get(), leaveSkippedRowsUnworked:get()))
+    elseif rowPattern:get() == cg.RowPattern.SPIRAL then
         context:setRowPattern(cg.RowPattern.create(rowPattern:get(), centerClockwise:get(), spiralFromInside:get()))
     elseif rowPattern:get() == cg.RowPattern.LANDS then
         context:setRowPattern(cg.RowPattern.create(rowPattern:get(), centerClockwise:get(), nRows:get()))
+    elseif rowPattern:get() == cg.RowPattern.RACETRACK then
+        context:setRowPattern(cg.RowPattern.create(rowPattern:get(), nRows:get()))
     else
-        context:setRowPattern(cg.RowPattern.create(rowPattern:get(), nRows:get(), leaveSkippedRowsUnworked:get()))
+        context:setRowPattern(cg.RowPattern.create(rowPattern:get()))
     end
     local generatorFunc
     if twoSided:get() then

--- a/main.lua
+++ b/main.lua
@@ -495,7 +495,12 @@ local function drawFields()
         local unpackedVertices = f:getUnpackedVertices()
         if #unpackedVertices > 2 then
             love.graphics.polygon('line', unpackedVertices)
-            for _, v in ipairs(f:getBoundary()) do
+            for i, v in ipairs(f:getBoundary()) do
+                if v:getRadius() < 10 then
+                    love.graphics.setColor(debugColor)
+                else
+                    love.graphics.setColor(fieldBoundaryColor)
+                end
                 love.graphics.points(v.x, v.y)
             end
             for _, i in ipairs(f:getIslands()) do
@@ -571,7 +576,8 @@ local function highlightPathAroundVertex(v)
 end
 
 local function highlightPathToNextRow(vertices)
-    for i, v in ipairs(vertices) do
+    for i = 1, #vertices - 1 do
+        local v = vertices[i]
         if v:getAttributes():isRowEnd() then
             local innermostHeadland = course:findPathToNextRow(v:getAttributes():getAtBoundaryId(),
                     v, course:getPath()[v.ix + 1], turningRadius:get())


### PR DESCRIPTION
Racetrack pattern now uses the rows to skip parameter so the size of blocks can be set when generating a course.